### PR TITLE
Docs: fix typos and parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Read the short blog: https://medium.com/@huyffs/fitted-textfield-container-for-f
 | Param             | Type        | Default      | Description                                                                                                    |
 |-------------------|-------------|--------------|----------------------------------------------------------------------------------------------------------------|
 | `child`           | `TextField` | * _required_ | The `TextField` to fit                                                                                         |
-| `prefixIconWidth` | `double`    | `48`         | Width of the `prefxiIcon` (if used)                                                                            |
-| `suffixIconWidth` | `double`    | `48`         | Width of the `suffxiIcon` (if used)                                                                            |
-| `prefixIconWidth` | `double`    | `null`       | Minimum width - `null` means there is no hard minimum width - it will depend on the `labelText` and `hintText` |
-| `prefixIconWidth` | `double`    | `null`       | Maximum width - `null` means the maximum width is only contrained by the parent widget                         |
+| `prefixIconWidth` | `double`    | `48`         | Width of the `prefixIcon` (if used)                                                                            |
+| `suffixIconWidth` | `double`    | `48`         | Width of the `suffixIcon` (if used)                                                                            |
+| `minWidth`        | `double`    | `null`       | Minimum width - `null` means there is no hard minimum width - it will depend on the `labelText` and `hintText` |
+| `maxWidth`        | `double`    | `null`       | Maximum width - `null` means the maximum width is only constrained by the parent widget                        |
 
 #### Example
 
@@ -41,8 +41,8 @@ FittedTextFieldContainer(
 | `shrinkCurve`     | `Curve`     | `Curves.easeInCirc`           | The curve to use in the shrink animation                                                                       |
 | `prefixIconWidth` | `double`    | `48`                          | Width of the `prefixIcon` (if used)                                                                            |
 | `suffixIconWidth` | `double`    | `48`                          | Width of the `suffixIcon` (if used)                                                                            |
-| `prefixIconWidth` | `double`    | `null`                        | Minimum width - `null` means there is no hard minimum width - it will depend on the `labelText` and `hintText` |
-| `prefixIconWidth` | `double`    | `null`                        | Maximum width - `null` means the maximum width is only contrained by the parent widget                         |
+| `minWidth`        | `double`    | `null`                        | Minimum width - `null` means there is no hard minimum width - it will depend on the `labelText` and `hintText` |
+| `maxWidth`        | `double`    | `null`                        | Maximum width - `null` means the maximum width is only constrained by the parent widget                        |
 
 
 #### Example

--- a/lib/src/animated_fitted_text_field_container.dart
+++ b/lib/src/animated_fitted_text_field_container.dart
@@ -14,7 +14,7 @@ class AnimatedFittedTextFieldContainer extends StatefulWidget {
   /// The `TextField` to wrap - the `controller` must not be `null`.
   final TextField child;
 
-  /// `Duration` for animating gtowth
+  /// `Duration` for animating growth
   final Duration growDuration;
 
   /// `Duration` to use for animating shrinkage
@@ -32,7 +32,7 @@ class AnimatedFittedTextFieldContainer extends StatefulWidget {
   /// The width of the `TextField.decoration.suffixIcon` if used
   final double suffixIconWidth;
 
-  /// The minimum width, if not set, the minimum width is 0 - i.e. there is no mimimum
+  /// The minimum width, if not set, the minimum width is 0 - i.e. there is no minimum
   final double minWidth;
 
   /// The maximum width, if not set, the minimum width is infinity - i.e. there is no maximum

--- a/lib/src/fitted_text_field_container.dart
+++ b/lib/src/fitted_text_field_container.dart
@@ -20,7 +20,7 @@ class FittedTextFieldContainer extends StatefulWidget {
   /// The width of the `TextField.decoration.suffixIcon` if used
   final double suffixIconWidth;
 
-  /// The minimum width, if not set, the minimum width is 0 - i.e. there is no mimimum
+  /// The minimum width, if not set, the minimum width is 0 - i.e. there is no minimum
   final double minWidth;
 
   /// The maximum width, if not set, the minimum width is infinity - i.e. there is no maximum


### PR DESCRIPTION
In the list of parameters, prefix/suffixIconWidth were accidentally
listed twice. The second instances were supposed to be min/maxWidth.