### PR TITLE
Create an option so that the text field collapses when the hint text disappears 

### DIFF
--- a/lib/src/animated_fitted_text_field_container.dart
+++ b/lib/src/animated_fitted_text_field_container.dart
@@ -106,7 +106,7 @@ class _AnimatedFittedTextFieldContainerState
     // in a multiline textfield and scrolled in a single-line text field.
     _fixedWidth += widget.child.cursorWidth + 1;
 
-    _textFieldWidth = _geTextFieldWidth();
+    _textFieldWidth = _getTextFieldWidth();
 
     super.didChangeDependencies();
   }
@@ -117,7 +117,7 @@ class _AnimatedFittedTextFieldContainerState
     super.dispose();
   }
 
-  double _geTextFieldWidth() {
+  double _getTextFieldWidth() {
     double textWidth = getTextSize(widget.child, _defaultTextStyle).width;
     double width = textWidth > _hintWidth ? textWidth : _hintWidth;
     if (_labelWidth > width) {
@@ -135,7 +135,7 @@ class _AnimatedFittedTextFieldContainerState
   }
 
   void _onTextChanged() {
-    final width = _geTextFieldWidth();
+    final width = _getTextFieldWidth();
     if (width != _textFieldWidth) {
       setState(() {
         if (width > _textFieldWidth) {

--- a/lib/src/animated_fitted_text_field_container.dart
+++ b/lib/src/animated_fitted_text_field_container.dart
@@ -42,6 +42,9 @@ class AnimatedFittedTextFieldContainer extends StatefulWidget {
   /// The builder provides the `child` TextField to a function that returns a widget.
   final Widget Function(BuildContext context, TextField child) builder;
 
+  /// If the min width should be based on the hint text, defaults to `true`
+  final bool minWidthFromHintText;
+
   const AnimatedFittedTextFieldContainer({
     Key key,
     this.child,
@@ -53,6 +56,7 @@ class AnimatedFittedTextFieldContainer extends StatefulWidget {
     this.suffixIconWidth = 48,
     this.minWidth = 0,
     this.maxWidth = double.infinity,
+    this.minWidthFromHintText = true,
     this.builder,
   }) : super(key: key);
   @override
@@ -85,8 +89,7 @@ class _AnimatedFittedTextFieldContainerState
   void didChangeDependencies() {
     // When style is null, it defaults to `subtitle1` of current field.
     // See: https://api.flutter.dev/flutter/material/TextField/style.html
-    _defaultTextStyle =
-        widget.child.style ?? Theme.of(context).textTheme.subhead;
+    _defaultTextStyle = widget.child.style;
 
     _prefixWidth = getPrefixTextSize(widget.child, _defaultTextStyle).width;
     _suffixWidth = getSuffixTextSize(widget.child, _defaultTextStyle).width;
@@ -118,8 +121,12 @@ class _AnimatedFittedTextFieldContainerState
   }
 
   double _getTextFieldWidth() {
-    double textWidth = getTextSize(widget.child, _defaultTextStyle).width;
-    double width = textWidth > _hintWidth ? textWidth : _hintWidth;
+    double width = getTextSize(widget.child, _defaultTextStyle).width;
+
+    if (widget.minWidthFromHintText || widget.child.controller.text == '') {
+      width = width > _hintWidth ? width : _hintWidth;
+    }
+
     if (_labelWidth > width) {
       width = _labelWidth;
     }

--- a/lib/src/fitted_text_field_container.dart
+++ b/lib/src/fitted_text_field_container.dart
@@ -27,6 +27,9 @@ class FittedTextFieldContainer extends StatefulWidget {
   /// The maximum width, defaults to `double.infinity` - i.e. there is no maximum
   final double maxWidth;
 
+  /// If the min width should be based on the hint text, defaults to `true`
+  final bool minWidthFromHintText;
+
   const FittedTextFieldContainer({
     Key key,
     @required this.child,
@@ -34,6 +37,7 @@ class FittedTextFieldContainer extends StatefulWidget {
     this.suffixIconWidth = 48,
     this.minWidth = 0,
     this.maxWidth = double.infinity,
+    this.minWidthFromHintText = true
   })  : assert(child != null),
         super(key: key);
 
@@ -62,8 +66,7 @@ class _FittedTextFieldContainerState extends State<FittedTextFieldContainer> {
   void didChangeDependencies() {
     // When style is null, it defaults to `subtitle1` of current field.
     // See: https://api.flutter.dev/flutter/material/TextField/style.html
-    _defaultTextStyle =
-        widget.child.style ?? Theme.of(context).textTheme.subhead;
+    _defaultTextStyle = widget.child.style;
 
     _prefixWidth = getPrefixTextSize(widget.child, _defaultTextStyle).width;
     _suffixWidth = getSuffixTextSize(widget.child, _defaultTextStyle).width;
@@ -93,8 +96,12 @@ class _FittedTextFieldContainerState extends State<FittedTextFieldContainer> {
   }
 
   double _getTextFieldWidth() {
-    double textWidth = getTextSize(widget.child, _defaultTextStyle).width;
-    double width = textWidth > _hintWidth ? textWidth : _hintWidth;
+    double width = getTextSize(widget.child, _defaultTextStyle).width;
+
+    if (widget.minWidthFromHintText || widget.child.controller.text == '') {
+      width = width > _hintWidth ? width : _hintWidth;
+    }
+
     if (_labelWidth > width) {
       width = _labelWidth;
     }

--- a/lib/src/fitted_text_field_container.dart
+++ b/lib/src/fitted_text_field_container.dart
@@ -81,7 +81,7 @@ class _FittedTextFieldContainerState extends State<FittedTextFieldContainer> {
     // Add enough space for the cursor to prevent it being positined onto the next line
     // in a multiline textfield and scrolled in a single-line text field.
     _fixedWidth += widget.child.cursorWidth + 1;
-    _textFieldWidth = _geTextFieldWidth();
+    _textFieldWidth = _getTextFieldWidth();
 
     super.didChangeDependencies();
   }
@@ -92,7 +92,7 @@ class _FittedTextFieldContainerState extends State<FittedTextFieldContainer> {
     super.dispose();
   }
 
-  double _geTextFieldWidth() {
+  double _getTextFieldWidth() {
     double textWidth = getTextSize(widget.child, _defaultTextStyle).width;
     double width = textWidth > _hintWidth ? textWidth : _hintWidth;
     if (_labelWidth > width) {
@@ -117,7 +117,7 @@ class _FittedTextFieldContainerState extends State<FittedTextFieldContainer> {
   }
 
   void _onTextChanged() {
-    final width = _geTextFieldWidth();
+    final width = _getTextFieldWidth();
     if (width != _textFieldWidth) {
       setState(() {
         _textFieldWidth = width;


### PR DESCRIPTION
The option is called minWidthFromHintText. If set to false, when the users type something, the text field collapses to the width of the current input and ignores the width of the hint text.

By the way, awesome package! It really helped me with my design 😄 